### PR TITLE
Add gobject-introspection-devel, vapigen and cmake to Fedora build in…

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ $ ninja -C builddir
 - [gtk-session-lock](https://github.com/Cu3PO42/gtk-session-lock)
 ### Installing build dependencies
 - Arch: `# pacman -S gcc meson pkgconf scdoc pam wayland gtk3 gtk-session-lock`
-- Fedora: `# dnf install gcc meson pkgconf scdoc pam-devel wayland-devel gtk3-devel`, install gtk-session-lock manually
+- Fedora: `# dnf install gcc meson pkgconf scdoc pam-devel wayland-devel gtk3-devel gobject-introspection-devel vapigen cmake`, install gtk-session-lock manually
 - Void: `# xbps-install gcc meson pkgconf scdoc pam-devel wayland-devel gtk+3-devel gtk-session-lock-devel`
 
 ❤️ __Please submit an dependency installation command for your distro!__


### PR DESCRIPTION
These packages are necessary for a `meson` build to work.

Testing evidence:

```
abc@fedora ~/gtklock (master) $ meson setup builddir
The Meson build system
Version: 1.5.1
Source dir: /home/abc/gtklock
Build dir: /home/abc/gtklock/builddir
Build type: native build
Project name: gtklock
Project version: 4.0.0
C compiler for the host machine: cc (gcc 14.2.1 "cc (GCC) 14.2.1 20240912 (Red Hat 14.2.1-3)")
C linker for the host machine: cc ld.bfd 2.43.1-4
Host machine cpu family: x86_64
Host machine cpu: x86_64
Found pkg-config: YES (/usr/bin/pkg-config) 2.3.0
Run-time dependency gtk+-3.0 found: YES 3.24.43
Found CMake: /usr/bin/cmake (3.30.5)
Run-time dependency gtk-session-lock-0 found: NO (tried pkgconfig and cmake)
Looking for a fallback subproject for the dependency gtk-session-lock-0

Executing subproject gtk-session-lock 

gtk-session-lock| Project name: gtk-session-lock
gtk-session-lock| Project version: 0.2.0
gtk-session-lock| C compiler for the host machine: cc (gcc 14.2.1 "cc (GCC) 14.2.1 20240912 (Red Hat 14.2.1-3)")
gtk-session-lock| C linker for the host machine: cc ld.bfd 2.43.1-4
gtk-session-lock| Dependency gtk+-3.0 found: YES 3.24.43 (cached)
gtk-session-lock| Run-time dependency wayland-client found: YES 1.23.0
gtk-session-lock| Run-time dependency wayland-server found: YES 1.23.0
gtk-session-lock| Build-time dependency wayland-scanner found: YES 1.23.0
gtk-session-lock| Run-time dependency wayland-protocols found: NO (tried pkgconfig and cmake)
gtk-session-lock| Program /usr/bin/wayland-scanner found: YES (/usr/bin/wayland-scanner)
gtk-session-lock| Run-time dependency gobject-introspection-1.0 found: YES 1.82.0
gtk-session-lock| Dependency gobject-introspection-1.0 found: YES 1.82.0 (cached)
gtk-session-lock| Program /usr/bin/g-ir-scanner found: YES (/usr/bin/g-ir-scanner)
gtk-session-lock| Dependency gobject-introspection-1.0 found: YES 1.82.0 (cached)
gtk-session-lock| Program /usr/bin/g-ir-compiler found: YES (/usr/bin/g-ir-compiler)
gtk-session-lock| Program vapigen found: YES (/usr/bin/vapigen)
gtk-session-lock| Program python3 found: YES (/usr/bin/python3)
gtk-session-lock| Build targets in project: 5
gtk-session-lock| NOTICE: Future-deprecated features used:
gtk-session-lock| * 0.56.0: {'dependency.get_pkgconfig_variable'}
gtk-session-lock| Subproject gtk-session-lock finished.

Dependency gtk-session-lock-0 from subproject subprojects/gtk-session-lock found: YES 0.2.0
Run-time dependency gmodule-export-2.0 found: YES 2.82.2
Library pam found: YES
Program msgfmt found: YES (/usr/bin/msgfmt)
Program msginit found: YES (/usr/bin/msginit)
Program msgmerge found: YES (/usr/bin/msgmerge)
Program xgettext found: YES (/usr/bin/xgettext)
Program scdoc found: YES (/usr/bin/scdoc)
Build-time dependency gio-2.0 found: YES 2.82.2
Program /usr/bin/glib-compile-resources found: YES (/usr/bin/glib-compile-resources)
Build targets in project: 17

gtklock 4.0.0

  Subprojects
    gtk-session-lock: YES 1 warnings

Found ninja-1.12.1 at /usr/bin/ninja
abc@fedora ~/gtklock (master) $ 
```